### PR TITLE
Lee/item setup

### DIFF
--- a/Content/Character/Animation/BPMG_CharacterPlayer.uasset
+++ b/Content/Character/Animation/BPMG_CharacterPlayer.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1cf8b113d710052005a48b50af1e5fb2e11b816981dc7aae2f2c5e9ba810147
-size 36388
+oid sha256:ecbe775669e4a5ddcebf6b20b435efe12d82371e6dad95e9009eb9c028e66da4
+size 40108

--- a/Content/Character/Input/IA_TestBooster.uasset
+++ b/Content/Character/Input/IA_TestBooster.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e47fb709faf077e77962ba7aeda6e0ad5746a1126482e53ccef16cb5835318ee
+size 1369

--- a/Content/Character/Input/IMC_Quater.uasset
+++ b/Content/Character/Input/IMC_Quater.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb8954b1ca0e9e1104e20eadd2f10f301b1843f988fb0185e32d0504221ec6d9
+oid sha256:0325cc211f4c92543b2baff7d42dfb5625d910ea6d94ddf7b992c21196a04c7a
 size 7395

--- a/Content/Character/Input/IMC_Shoulder.uasset
+++ b/Content/Character/Input/IMC_Shoulder.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9fd34ce082c634f4bfeb1d0a2ed52f1058e4ae9bf7e9aec5d1803bcff2d61e9
+oid sha256:643b39bf8d2fe3e91dbd8d23e745fa0f8859f5c6708d6e8f6109bb567af52f50
 size 8079

--- a/Content/Lobby/Item/BP_ItemActor.uasset
+++ b/Content/Lobby/Item/BP_ItemActor.uasset
@@ -1,5 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-
 oid sha256:b0b830847cd92d0145297f6299ee51d7cf771f294e833beafd27fbf56192b045
 size 35316
-

--- a/Content/Lobby/ThirdPerson/Blueprints/GameMap/BP_GM_GameMap.uasset
+++ b/Content/Lobby/ThirdPerson/Blueprints/GameMap/BP_GM_GameMap.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93ee8818f56028c878561cf6f9d4210f3fb1553ce6e460ef6dbea6e13d3f85e9
-size 20939
+oid sha256:4d0e142233f50449f05173c9cead88838f7963e871e6dd3475f4b7ed54a11531
+size 21060

--- a/Content/Lobby/ThirdPerson/Maps/TempGameMap.umap
+++ b/Content/Lobby/ThirdPerson/Maps/TempGameMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db5ef44213aa7145ee7b61e542383c4565426a62a909cdc27e798b25204b5beb
+oid sha256:a158aa7213b894affcc98432b11bb0512ef5474486404c15aa1c4889d6ae1af3
 size 46851

--- a/Source/StackOBot/Minigames/BasePlayerState.h
+++ b/Source/StackOBot/Minigames/BasePlayerState.h
@@ -49,7 +49,7 @@ protected:
 // ------------ Selected Character's ----------------------
 protected:
 	UPROPERTY(ReplicatedUsing = OnRep_SelectedCharacter)
-	FString SelectedCharacter = "Quinn";
+	FString SelectedCharacter = "Bot";
 
 public:
 	virtual void SetSelectedCharacter(FString NewCharacter);

--- a/Source/StackOBot/Minigames/GameMap/GameMapGameMode.cpp
+++ b/Source/StackOBot/Minigames/GameMap/GameMapGameMode.cpp
@@ -7,6 +7,15 @@
 #include "GamePlayerController.h"
 
 
+AGameMapGameMode::AGameMapGameMode()
+{
+	for (auto ItemClass : ItemClasses)
+	{
+		UItemBase* Item = NewObject<UItemBase>(this, ItemClass);
+		AvailableItems.Add(Item);
+	}
+}
+
 void AGameMapGameMode::RestartPlayerAtPlayerStart(AController* NewPlayer, AActor* StartSpot)
 {
 	ABasePlayerState* PS = NewPlayer->GetPlayerState<ABasePlayerState>();
@@ -63,5 +72,17 @@ void AGameMapGameMode::HandleMatchHasEnded()
 	Super::HandleMatchHasEnded();
 
 	GetWorld()->ServerTravel("/Game/Lobby/ThirdPerson/Maps/LobbyMap");
+}
+
+UItemBase* AGameMapGameMode::GetItem()
+{
+	if (AvailableItems.IsEmpty())
+	{
+		return nullptr;
+	}
+
+	
+	// 우선은 0번아이템 전달.
+	return AvailableItems[0];
 }
 

--- a/Source/StackOBot/Minigames/GameMap/GameMapGameMode.h
+++ b/Source/StackOBot/Minigames/GameMap/GameMapGameMode.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "../Item/ItemBase.h"
 #include "GameFramework/GameMode.h"
 #include "GameMapGameMode.generated.h"
 
@@ -13,6 +14,8 @@ UCLASS()
 class STACKOBOT_API AGameMapGameMode : public AGameMode
 {
 	GENERATED_BODY()
+
+	AGameMapGameMode();
 	
 public:
 	virtual void RestartPlayerAtPlayerStart(AController* NewPlayer, AActor* StartSpot) override;
@@ -23,4 +26,15 @@ public:
 protected:
 	//virtual void OnMatchStateSet() override;
 	virtual void HandleMatchHasEnded() override;
+
+
+// --------- Item List --------
+protected:
+	UPROPERTY(EditAnywhere);
+	TArray< TSubclassOf<UItemBase>> ItemClasses;
+	TArray<UItemBase*> AvailableItems;
+
+public:
+	UItemBase* GetItem();
+	
 };

--- a/Source/StackOBot/Minigames/GameMap/GamePlayerState.cpp
+++ b/Source/StackOBot/Minigames/GameMap/GamePlayerState.cpp
@@ -3,6 +3,8 @@
 
 #include "GamePlayerState.h"
 #include "../ThirdPersonCharacter.h"
+#include "../Item/ItemBase.h"
+#include "Net/UnrealNetwork.h"
 
 void AGamePlayerState::BeginPlay()
 {
@@ -71,4 +73,40 @@ void AGamePlayerState::SetPlayerPawn(APlayerState* Player, APawn* NewPawn, APawn
 
 	}
 
+}
+
+void AGamePlayerState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+
+	DOREPLIFETIME(AGamePlayerState, CurrentItem);
+
+}
+
+void AGamePlayerState::OnRep_CurrentItem()
+{
+	// client's UI 변경...
+}
+
+void AGamePlayerState::GetNewItem(UItemBase* NewItem)
+{
+	if (CurrentItem == nullptr && HasAuthority())
+	{
+		CurrentItem = NewItem;
+		// Update Server's UI. 
+	}
+}
+
+void AGamePlayerState::UseItem()
+{
+	if (HasAuthority())
+	{
+		APawn* Pawn = GetPawn();
+		if (!IsValid(Pawn))
+		{
+			return;
+		}
+		CurrentItem->ActivateItem(Pawn);
+	}
 }

--- a/Source/StackOBot/Minigames/GameMap/GamePlayerState.h
+++ b/Source/StackOBot/Minigames/GameMap/GamePlayerState.h
@@ -33,4 +33,18 @@ public:
 	// Call when OnPawnSet Done. Since TeamColor is not replicated, Do Initial Paint.
 	UFUNCTION()
 	void SetPlayerPawn(APlayerState* Player, APawn* NewPawn, APawn* OldPawn);
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+// --------- ITEM ----------
+protected:
+	UPROPERTY(ReplicatedUsing = OnRep_CurrentItem)
+	class UItemBase* CurrentItem;
+
+	UFUNCTION()
+	void OnRep_CurrentItem();
+
+public:
+	void GetNewItem(class UItemBase* NewItem);
+	void UseItem();
+
 };

--- a/Source/StackOBot/Minigames/Item/ItemActor.cpp
+++ b/Source/StackOBot/Minigames/Item/ItemActor.cpp
@@ -4,6 +4,8 @@
 #include "ItemActor.h"
 #include "../GameMap/GamePlayerState.h"
 #include "../GameMap/CoinGame/CoinGameState.h"
+#include "../GameMap/GameMapGameMode.h"
+#include "StackOBot.h"
 //게임 모드랑 게임 스테이트 추가 해야 함 
 // 
 // Sets default values
@@ -61,24 +63,35 @@ void AItemActor::OnBoxComponentOverlapped(
 {
 	if (OtherActor->IsA<ACharacter>() && HasAuthority())
 	{
-		GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Green, TEXT("Box Overlapped with character"));
-		AGamePlayerState* PS = Cast<ACharacter>(OtherActor)->GetPlayerState<AGamePlayerState>();
-		if (!IsValid(PS))
-		{
-			GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Red, TEXT("PS Not Valid : ItemActor Overlapped"));
-			return;
-		}
-		//player score add.
-		PS->TrySetScore(PS->GetScore() + 1.f);
+		//GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Green, TEXT("Box Overlapped with character"));
+		//AGamePlayerState* PS = Cast<ACharacter>(OtherActor)->GetPlayerState<AGamePlayerState>();
+		//if (!IsValid(PS))
+		//{
+		//	GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Red, TEXT("PS Not Valid : ItemActor Overlapped"));
+		//	return;
+		//}
+		////player score add.
+		//PS->TrySetScore(PS->GetScore() + 1.f);
 
-		// team score add.
-		auto* CoinGS = GetWorld()->GetGameState<ACoinGameState>();
-		if (!IsValid(CoinGS))
+		//// team score add.
+		//auto* CoinGS = GetWorld()->GetGameState<ACoinGameState>();
+		//if (!IsValid(CoinGS))
+		//{
+		//	GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Red, TEXT("GS Not Valid : ItemActor Overlapped"));
+		//	return;
+		//}
+		//CoinGS->SetTeamScore(PS->GetIsRedTeam(), CoinGS->GetTeamScore(PS->GetIsRedTeam()) + 1);
+
+		UItemBase* NewItem = GetWorld()->GetAuthGameMode<AGameMapGameMode>()->GetItem();
+
+		if (!IsValid(NewItem))
 		{
-			GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Red, TEXT("GS Not Valid : ItemActor Overlapped"));
+			MG_LOG(LogMiniGame, Log, TEXT("%s"), TEXT("ItemActor에서 GetItem 실패"));
 			return;
 		}
-		CoinGS->SetTeamScore(PS->GetIsRedTeam(), CoinGS->GetTeamScore(PS->GetIsRedTeam()) + 1);
+		// Player State의 item에 넣기.
+
+
 		Destroy();
 	}
 }

--- a/Source/StackOBot/Minigames/Item/ItemBase.cpp
+++ b/Source/StackOBot/Minigames/Item/ItemBase.cpp
@@ -1,0 +1,14 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "ItemBase.h"
+
+FString& UItemBase::GetItemName()
+{
+	// TODO: 여기에 return 문을 삽입합니다.
+	return ItemName;
+}
+
+void UItemBase::ActivateItem()
+{
+}

--- a/Source/StackOBot/Minigames/Item/ItemBase.cpp
+++ b/Source/StackOBot/Minigames/Item/ItemBase.cpp
@@ -9,6 +9,6 @@ FString& UItemBase::GetItemName()
 	return ItemName;
 }
 
-void UItemBase::ActivateItem()
+void UItemBase::ActivateItem(APawn* const ItemUser)
 {
 }

--- a/Source/StackOBot/Minigames/Item/ItemBase.h
+++ b/Source/StackOBot/Minigames/Item/ItemBase.h
@@ -1,0 +1,24 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "ItemBase.generated.h"
+
+/**
+ * 
+ */
+UCLASS(Abstract)
+class STACKOBOT_API UItemBase : public UObject
+{
+	GENERATED_BODY()
+
+protected:
+	FString ItemName;
+public:
+	FString& GetItemName();
+public:
+	virtual void ActivateItem();
+	
+};

--- a/Source/StackOBot/Minigames/Item/ItemBooster.cpp
+++ b/Source/StackOBot/Minigames/Item/ItemBooster.cpp
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Minigames/Item/ItemBooster.h"
+#include "../OBot/Character/MG_CharacterPlayer.h"
+
+
+void UItemBooster::ActivateItem(APawn* const ItemUser)
+{
+	AMG_CharacterPlayer* ItemUserBot = Cast<AMG_CharacterPlayer>(ItemUser);
+	if (!IsValid(ItemUserBot))
+	{
+		GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Red, TEXT("ItemUserBot Not Valid : UItemBooster::ActivateItem()"));
+		return;
+	}
+
+	// TODO : 캐릭터의 부스트 함수 호출.(OnUseBooserItem)
+	ItemUserBot->OnBoosterItem();
+
+}

--- a/Source/StackOBot/Minigames/Item/ItemBooster.h
+++ b/Source/StackOBot/Minigames/Item/ItemBooster.h
@@ -3,22 +3,17 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/NoExportTypes.h"
-#include "ItemBase.generated.h"
+#include "Minigames/Item/ItemBase.h"
+#include "ItemBooster.generated.h"
 
 /**
  * 
  */
-UCLASS(Abstract, Blueprintable)
-class STACKOBOT_API UItemBase : public UObject
+UCLASS()
+class STACKOBOT_API UItemBooster : public UItemBase
 {
 	GENERATED_BODY()
 
-protected:
-	FString ItemName;
-public:
-	FString& GetItemName();
 public:
 	virtual void ActivateItem(APawn* const ItemUser);
-	
 };

--- a/Source/StackOBot/Minigames/OBot/Character/MG_CharacterPlayer.cpp
+++ b/Source/StackOBot/Minigames/OBot/Character/MG_CharacterPlayer.cpp
@@ -98,6 +98,8 @@ void AMG_CharacterPlayer::BeginPlay()
 		EnableInput(PlayerController);
 	}
 	SetCharacterControl(CurrentCharacterControlType);
+
+
 }
 
 void AMG_CharacterPlayer::Tick(float DeltaTime)
@@ -402,4 +404,19 @@ void AMG_CharacterPlayer::StopJumping()
 	{
 		ServerStopHover();
 	}
+}
+
+void AMG_CharacterPlayer::OnBoosterItem()
+{
+	// 잠시 동안만...
+	GetCharacterMovement()->MaxWalkSpeed = 1500.f;
+
+	GetWorldTimerManager().SetTimer(Timer, this, &ThisClass::OnBoosterEnd, 3.f, false);
+	
+}
+
+void AMG_CharacterPlayer::OnBoosterEnd()
+{
+	GetCharacterMovement()->MaxWalkSpeed = 500.f;
+
 }

--- a/Source/StackOBot/Minigames/OBot/Character/MG_CharacterPlayer.h
+++ b/Source/StackOBot/Minigames/OBot/Character/MG_CharacterPlayer.h
@@ -122,4 +122,13 @@ protected:
 private:
 	bool bIsJetpackActive;
 	bool bIsHovering;
+
+// ---------- Item Functions ------------
+public:
+	UFUNCTION(BlueprintCallable)
+	void OnBoosterItem();
+
+protected:
+	void OnBoosterEnd();
+	FTimerHandle Timer;
 };

--- a/StackOBot.uproject
+++ b/StackOBot.uproject
@@ -10,7 +10,8 @@
 			"LoadingPhase": "Default",
 			"AdditionalDependencies": [
 				"UMG",
-				"Engine"
+				"Engine",
+				"CoreUObject"
 			]
 		}
 	],


### PR DESCRIPTION
아이템 베이스 클래스 제작. 베이스를 상속받는 ItemBooster제작.
 - 게임맵게임모드에서 사용가능한 아이템들을 지정하고 리스트를 가지고 있게 하였음.
 - 새 아이템을 가져와야 하는 경우 게임모드의 GetItem()함수에서 가져가면 될 것.
 - 그 아이템의 ActivateItem()함수를 실행하면 아이템의 로직이 실행됨.
 - 우선 부스터의 경우 캐릭터에 새로 만들어 놓은 OnBooster함수를 실행.